### PR TITLE
tpm2_getcap: delete unused references of -c parameter

### DIFF
--- a/man/tpm2_getcap.1.md
+++ b/man/tpm2_getcap.1.md
@@ -14,23 +14,23 @@
 them to the console. It takes a string form of the capability to query as an
 argument to the tool. Currently supported capability groups are:
 
-- **properties-fixed**:
-  Display fixed TPM properties.
-
-- **properties-variable**:
-  Display variable TPM properties.
-
 - **algorithms**:
   Display data about supported algorithms.
 
 - **commands**:
   Display data about supported commands.
 
-- **ecc-curves**:
-  Display data about elliptic curves.
-
 - **pcrs**:
   Display currently allocated PCRs.
+
+- **properties-fixed**:
+  Display fixed TPM properties.
+
+- **properties-variable**:
+  Display variable TPM properties.
+
+- **ecc-curves**:
+  Display data about elliptic curves.
 
 - **handles-transient**:
   Display handles about transient objects.
@@ -80,7 +80,7 @@ argument to the tool. Currently supported capability groups are:
 tpm2_getcap properties-fixed
 ```
 
-## To list the supported capability arguments to **-c**
+## To list the supported capability groups
 ```bash
 tpm2_getcap -l
 ```

--- a/tools/tpm2_getcap.c
+++ b/tools/tpm2_getcap.c
@@ -784,10 +784,9 @@ static bool dump_tpm_capability(TPMU_CAPABILITIES *capabilities) {
 
 static bool on_option(char key, char *value) {
 
+    UNUSED(value);
+
     switch (key) {
-    case 'c':
-        options.capability_string = value;
-        break;
     case 'l':
         options.list = true;
     }
@@ -824,7 +823,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
     UNUSED(flags);
 
     if (options.list && options.capability_string) {
-        LOG_ERR("Cannot specify -l with -c.");
+        LOG_ERR("Cannot specify -l with a capability group.");
         return tool_rc_option_error;
     }
 
@@ -834,7 +833,7 @@ tool_rc tpm2_tool_onrun(ESYS_CONTEXT *context, tpm2_option_flags flags) {
         return tool_rc_success;
     }
 
-    /* List a capability, ie -c <arg> option */
+    /* List a capability, ie <capability group> option */
     TPMS_CAPABILITY_DATA *capability_data = NULL;
 
     bool ret = sanity_check_capability_opts();


### PR DESCRIPTION
in  tpm2_getcap.c:
- Remove obsolete case using -c parameter.
- Delete reference of -c parameter in an error message.
- Delete reference of -c parameter in a code comment.

and update the list of capability groups in the tpm2_getcap man page to match the list from `tpm2_getcap -l`